### PR TITLE
Add Cloupload Web

### DIFF
--- a/third-party-apps.md
+++ b/third-party-apps.md
@@ -14,6 +14,7 @@ examples:
 * **[ClouDrop](http://itunes.apple.com/us/app/cloudrop-for-cloudapp/id493848413?mt=8)**: full-featured CloudApp iOS app
 * [CloudSend](http://www.trijstudios.com/cloudsend): Send websites and videos from your computer to your iPhone using CloudApp.
 * [Cloupload](http://cloupload.gidix.net/): full-featured Android client with file previews
+* [Cloupload Web](https://github.com/bluefirex/cloupload-web): the CloudApp web client reimagined
 * [DropBook](http://itunes.apple.com/us/app/dropbook/id408384997?mt=12): share to Facebook using CloudApp
 * [Doxie](http://www.getdoxie.com/): scan directly into the cloud
 * [Finapp](http://www.windowsphone.com/en-gb/store/app/finapp/ec4ab022-bb0d-4805-87c5-c0967a33aa55): a simple CloudApp client for Windows Phone


### PR DESCRIPTION
Cloupload Web is a web client for CloudApp that runs in your browser.
https://github.com/bluefirex/cloupload-web

I added it to this list.
